### PR TITLE
feat: migrate to AsyncHiveMessageBusClient (composition over inheritance)

### DIFF
--- a/hm_deltachat_bridge/__init__.py
+++ b/hm_deltachat_bridge/__init__.py
@@ -1,42 +1,169 @@
-from hivemind_bus_client.client import HiveMessageBusClient
+"""HiveMind ⇄ DeltaChat bridge.
+
+Composition design (replaces the previous inheritance-based bridge):
+
+- :class:`hm_deltachat_bridge.deltabot.DeltaChatBot` — wraps the classic
+  ``deltachat`` Python library, runs its blocking ``account.wait_shutdown()``
+  on a daemon thread, fires ``handle_utterance(text, addr)`` from
+  the deltachat library's internal thread when a chat message arrives.
+- :class:`AsyncHiveMessageBusClient` — asyncio-native HiveMind client
+  (``hivemind-bus-client[async]>=0.8.0``). Runs on the application's
+  event loop.
+- :class:`HiveMindDeltaChatBridge` — composes the two. The deltachat
+  callback (which fires on the deltachat thread) is bridged onto the
+  asyncio loop with :func:`asyncio.run_coroutine_threadsafe`; the
+  HiveMind ``speak`` handler runs on the receive task and calls
+  ``DeltaChatBot.speak`` directly (the deltachat client library is
+  thread-safe for the calls we use).
+
+This removes the previous architecture's *second* thread (the sync
+``HiveMessageBusClient.run_in_thread``). One thread remains — the
+deltachat library's own — because the classic ``deltachat`` package is
+fundamentally callback-based and not asyncio-aware. Migrating to
+``deltachat-rpc-client`` (async-first) is a separate, larger change
+that would also drop that thread.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from hivemind_bus_client.async_client import AsyncHiveMessageBusClient
+from hivemind_bus_client.identity import NodeIdentity
+from ovos_bus_client.message import Message
 from ovos_utils.log import LOG
-from ovos_utils.messagebus import FakeBus
-from ovos_utils.messagebus import Message
 
 from hm_deltachat_bridge.deltabot import DeltaChatBot
 from hm_deltachat_bridge.version import __version__
 
 
-class HiveMindDeltaChatBridge(HiveMessageBusClient):
-    platform = "HiveMindDeltaChatBridgeV0.1"
+class HiveMindDeltaChatBridge:
+    """Bridge between a DeltaChat account and a HiveMind hub.
 
-    def __init__(self, email, email_password, *args, **kwargs):
-        self.bot = DeltaChatBot(email, email_password)
-        self.bot.handle_utterance = self.handle_delta_utterance
+    Typical usage from an asyncio entry point::
+
+        bridge = HiveMindDeltaChatBridge(
+            email="user@example.com",
+            email_password="...",
+            identity=NodeIdentity(),
+        )
+        await bridge.start()
+        try:
+            await stop_event.wait()
+        finally:
+            await bridge.stop()
+
+    For DI in tests, pass a pre-built ``client`` (any object matching the
+    :class:`AsyncHiveMessageBusClient` surface — including
+    ``hivemind_bus_client.fakebus.AsyncFakeHiveMessageBus``) and/or a
+    pre-built ``bot``.
+    """
+
+    platform = "HiveMindDeltaChatBridgeV0.2"
+
+    def __init__(self,
+                 email: Optional[str] = None,
+                 email_password: Optional[str] = None,
+                 key: Optional[str] = None,
+                 password: Optional[str] = None,
+                 host: Optional[str] = None,
+                 port: Optional[int] = None,
+                 identity: Optional[NodeIdentity] = None,
+                 *,
+                 client: Optional[AsyncHiveMessageBusClient] = None,
+                 bot: Optional[DeltaChatBot] = None):
+        self.bot = bot or DeltaChatBot(email=email, password=email_password)
+        self.client = client or AsyncHiveMessageBusClient(
+            key=key,
+            password=password,
+            host=host,
+            port=port,
+            useragent=self.platform,
+            identity=identity,
+        )
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._started = False
+
+    # ------------------------------------------------------------------
+    # lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Wire deltachat -> asyncio bridge, connect to HiveMind, start bot."""
+        if self._started:
+            return
+        self._loop = asyncio.get_running_loop()
+        self.bot.handle_utterance = self._on_delta_utterance
         self.bot.start()
         LOG.info("== connected to DeltaChat")
-        super().__init__(*args, **kwargs)
-        self.connect(FakeBus(), site_id="deltachat")
-        self.on_mycroft("speak", self.handle_incoming_mycroft)
+
+        await self.client.connect(site_id="deltachat")
+        # speak events on the OVOS bus carry the deltachat_addr we tagged
+        # on the outbound utterance; route them back to deltachat.
+        self.client.on_mycroft("speak", self._on_speak)
         LOG.info("== connected to HiveMind")
+        self._started = True
 
-    def stop(self):
-        self.bot.stop()
+    async def stop(self) -> None:
+        """Shutdown bot, close HiveMind connection. Idempotent."""
+        if not self._started:
+            return
+        try:
+            self.client.remove("speak", self._on_speak)
+        except Exception:
+            pass
+        try:
+            self.bot.stop()
+        except Exception:
+            LOG.exception("error stopping DeltaChat bot")
+        try:
+            await self.client.close()
+        except Exception:
+            LOG.exception("error closing HiveMind client")
+        self._started = False
 
-    def handle_delta_utterance(self, utterance, addr):
+    # ------------------------------------------------------------------
+    # deltachat -> HiveMind (callback runs on deltachat lib thread)
+    # ------------------------------------------------------------------
+
+    def _on_delta_utterance(self, utterance: str, addr: str) -> None:
+        """Bridge the deltachat-thread callback onto the asyncio loop.
+
+        ``asyncio.run_coroutine_threadsafe`` is the documented way to
+        schedule an awaitable from a non-loop thread — it returns
+        immediately; the loop runs the coroutine on its next pass.
+        """
+        if self._loop is None or self._loop.is_closed():
+            LOG.warning("got deltachat utterance before bridge started; dropping")
+            return
         LOG.debug(f"asking hivemind: {utterance}")
-        # TODO - lang detect here
-        self.emit_mycroft(
+        # TODO - language detection here
+        coro = self.client.emit_mycroft(
             Message("recognizer_loop:utterance",
                     {"utterances": [utterance]},
                     {"deltachat_addr": addr})
         )
+        asyncio.run_coroutine_threadsafe(coro, self._loop)
 
-    def handle_incoming_mycroft(self, message):
-        utterance = message.data["utterance"]
+    # ------------------------------------------------------------------
+    # HiveMind -> deltachat (handler runs on the asyncio receive task)
+    # ------------------------------------------------------------------
+
+    def _on_speak(self, message) -> None:
+        """OVOS ``speak`` message arrived from HiveMind. Forward to deltachat.
+
+        ``self.bot.speak`` is the synchronous deltachat library call to
+        ``chat.send_text``. We are already on the asyncio loop here, but the
+        deltachat library is thread-safe for send_text so calling it sync
+        from a loop handler is fine — no need to offload to a thread pool.
+        """
+        utterance = message.data.get("utterance")
         addr = message.context.get("deltachat_addr")
         if not addr:
             LOG.error("got speak message without deltachat_addr")
-        else:
-            LOG.info(f"HiveMind {addr} : {utterance}")
+            return
+        LOG.info(f"HiveMind {addr} : {utterance}")
+        try:
             self.bot.speak(utterance, addr)
+        except Exception:
+            LOG.exception(f"failed to forward speak to deltachat addr={addr}")

--- a/hm_deltachat_bridge/__main__.py
+++ b/hm_deltachat_bridge/__main__.py
@@ -1,6 +1,11 @@
+"""CLI entry point — asyncio main with signal-driven shutdown."""
+from __future__ import annotations
+
+import asyncio
+import signal
+
 import click
 from hivemind_bus_client.identity import NodeIdentity
-from ovos_utils import wait_for_exit_signal
 from ovos_utils.log import LOG
 
 from hm_deltachat_bridge import HiveMindDeltaChatBridge
@@ -8,34 +13,59 @@ from hm_deltachat_bridge import HiveMindDeltaChatBridge
 LOG.set_level("DEBUG")
 
 
-# TODO - allowed emails option
-@click.command()
-@click.option("--email", help="deltachat email", type=str)
-@click.option("--email-password", help="deltachat email password", type=str)
-@click.option("--key", help="HiveMind access key (default read from identity file)", type=str, default="")
-@click.option("--password", help="HiveMind password (default read from identity file)", type=str, default="")
-@click.option("--host", help="HiveMind host (default read from identity file)", type=str, default="")
-@click.option("--port", help="HiveMind port number (default: 5678)", type=int, default=5678)
-def launch_bot(email: str, email_password: str,
-               key: str, password: str, host: str, port: int):
+async def _amain(email: str, email_password: str,
+                 key: str, password: str, host: str, port: int) -> None:
     identity = NodeIdentity()
     password = password or identity.password
     key = key or identity.access_key
     host = host or identity.default_master
 
-    if not host.startswith("ws://") and not host.startswith("wss://"):
+    if host and not host.startswith("ws://") and not host.startswith("wss://"):
         host = "ws://" + host
 
     if not key or not password or not host:
-        raise RuntimeError("NodeIdentity not set, please pass key/password/host or "
-                           "call 'hivemind-client set-identity'")
+        raise RuntimeError(
+            "NodeIdentity not set, please pass key/password/host or "
+            "call 'hivemind-client set-identity'"
+        )
 
-    node = HiveMindDeltaChatBridge(email=email, email_password=email_password,
-                                   key=key, host=host, port=port, password=password)
+    bridge = HiveMindDeltaChatBridge(
+        email=email, email_password=email_password,
+        key=key, host=host, port=port, password=password,
+    )
 
-    wait_for_exit_signal()
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, stop_event.set)
+        except NotImplementedError:
+            # Windows doesn't support add_signal_handler; let KeyboardInterrupt fall through.
+            pass
 
-    node.stop()
+    await bridge.start()
+    try:
+        await stop_event.wait()
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        pass
+    finally:
+        await bridge.stop()
+
+
+# TODO - allowed emails option
+@click.command()
+@click.option("--email", help="deltachat email", type=str)
+@click.option("--email-password", help="deltachat email password", type=str)
+@click.option("--key", help="HiveMind access key (default read from identity file)",
+              type=str, default="")
+@click.option("--password", help="HiveMind password (default read from identity file)",
+              type=str, default="")
+@click.option("--host", help="HiveMind host (default read from identity file)",
+              type=str, default="")
+@click.option("--port", help="HiveMind port number (default: 5678)", type=int, default=5678)
+def launch_bot(email: str, email_password: str,
+               key: str, password: str, host: str, port: int) -> None:
+    asyncio.run(_amain(email, email_password, key, password, host, port))
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hivemind-bus-client>=0.9.2a1,<1.0.0
+hivemind-bus-client[async]>=0.9.2a1,<1.0.0
 ovos-utils
 click
 deltachat

--- a/tests/e2e/test_bridge_hivemind_e2e.py
+++ b/tests/e2e/test_bridge_hivemind_e2e.py
@@ -5,16 +5,15 @@ hivemind-core hub:
 
     inbound DeltaChat message
         -> DeltaChatBot.ac_incoming_message  (real bridge bot logic)
-        -> bridge.handle_delta_utterance     (real bridge method)
-        -> emit_mycroft(recognizer_loop:utterance)  -> real WebSocket
-        -> hivemind-core hub  -> agent bus
+        -> bridge._on_delta_utterance        (real bridge method, deltachat thread)
+        -> asyncio.run_coroutine_threadsafe -> client.emit_mycroft
+        -> real WebSocket -> hivemind-core hub -> agent bus
         -> responding agent emits `speak` back to the originating peer
-        -> real WebSocket -> bridge.internal_bus
-        -> bridge.handle_incoming_mycroft     (real bridge method)
+        -> real WebSocket -> bridge._on_speak (real bridge method, asyncio task)
         -> bot.speak(utterance, addr)         -> chat.send_text  (captured)
 
-Everything between ``emit_mycroft`` and ``handle_incoming_mycroft`` is the
-genuine production HiveMessageBusClient + hivemind-core stack over a localhost
+Everything between ``emit_mycroft`` and ``_on_speak`` is the genuine
+production AsyncHiveMessageBusClient + hivemind-core stack over a localhost
 WebSocket (hivescope's loopback hub). Only the DeltaChat *transport* is mocked:
 the ``deltachat`` library is never imported and no email/chatmail account is
 needed. The mock captures the bridge's outbound ``chat.send_text`` so the
@@ -30,7 +29,9 @@ Reference (HiveMind harness):
     hivemind-test-harness/tests/test_cascade.py
         responder on master.agent_protocol.bus.on("recognizer_loop:utterance")
 """
+import asyncio
 import sys
+import threading
 import time
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
@@ -152,28 +153,45 @@ def _extract_host_port(url: str):
     return parts[0], int(parts[1])
 
 
-def _make_bridge(url, key, password, bot):
-    """Construct the REAL bridge wired to the loopback hub, reusing `bot`.
+class _BridgeRunner:
+    """Run the async bridge on a dedicated asyncio loop thread.
 
-    HiveMindDeltaChatBridge.__init__ builds its own DeltaChatBot and calls
-    super().__init__()/connect(). We patch DeltaChatBot construction to return
-    our prepared bot instance so the inbound/outbound DeltaChat side is the
-    fake transport, while the HiveMessageBusClient + connect() are 100% real.
+    The bridge is asyncio-native (``await bridge.start()``); the hivescope hub
+    and the test body are synchronous. This runner mirrors production: the
+    bridge's loop is the "application loop", the test thread plays the role of
+    the deltachat library thread when it fires ``ac_incoming_message``.
     """
-    host, port = _extract_host_port(url)
-    return HiveMindDeltaChatBridge(
-        email="bot@example.org",
-        email_password="hunter2",
-        key=key,
-        password=password,
-        host=f"ws://{host}",
-        port=port,
-        useragent="dc-bridge-e2e",
-        self_signed=False,
-    )
+
+    def __init__(self, url, key, password, bot):
+        host, port = _extract_host_port(url)
+        self.bridge = HiveMindDeltaChatBridge(
+            key=key,
+            password=password,
+            host=f"ws://{host}",
+            port=port,
+            bot=bot,
+        )
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._loop.run_forever,
+                                        daemon=True)
+
+    def start(self, timeout=10):
+        self._thread.start()
+        fut = asyncio.run_coroutine_threadsafe(self.bridge.start(), self._loop)
+        fut.result(timeout=timeout)  # start() awaits the handshake
+
+    def close(self):
+        try:
+            fut = asyncio.run_coroutine_threadsafe(self.bridge.stop(),
+                                                   self._loop)
+            fut.result(timeout=10)
+        finally:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._thread.join(timeout=5)
+            self._loop.close()
 
 
-def test_deltachat_to_hivemind_roundtrip(monkeypatch):
+def test_deltachat_to_hivemind_roundtrip():
     """Full round-trip: DeltaChat in -> HiveMind hub -> DeltaChat out.
 
     Proves the bridge relays a user's DeltaChat utterance to a real hub, the
@@ -188,7 +206,7 @@ def test_deltachat_to_hivemind_roundtrip(monkeypatch):
     b = TopologyBuilder()
     m = b.add_master("M0", use_loopback=True)
     # whitelist-only ACL: grant the only type the bridge injects.
-    m.register_satellite("dc-key", password="dc-password",
+    m.register_satellite("dc-key", password="dc-Xk39vLq2mN8w-e2e",
                          allowed_types=["recognizer_loop:utterance"])
     b.start_all()
 
@@ -217,17 +235,14 @@ def test_deltachat_to_hivemind_roundtrip(monkeypatch):
         # --- prepare the bridge's DeltaChat bot (fake transport) -------------
         # Use the bridge's REAL DeltaChatBot class (its ac_incoming_message and
         # speak() are the genuine bridge logic); only the deltachat lib under it
-        # is faked. We construct it ourselves and hand it to the bridge.
+        # is faked. We construct it ourselves and hand it to the bridge (DI).
         bot = DeltaChatBot(email="bot@example.org", password="hunter2")
-        monkeypatch.setattr("hm_deltachat_bridge.DeltaChatBot",
-                            lambda *a, **k: bot)
         # don't spin real IO threads
         bot.start = MagicMock()
 
         url = m.network_protocol.url
-        bridge = _make_bridge(url, "dc-key", "dc-password", bot)
-        bridge.wait_for_handshake(timeout=10)
-        assert bridge.handshake_event.is_set(), "bridge handshake did not complete"
+        bridge = _BridgeRunner(url, "dc-key", "dc-Xk39vLq2mN8w-e2e", bot)
+        bridge.start(timeout=10)  # completes the HiveMind handshake
         time.sleep(1)  # let the encrypted HELLO register the peer
         assert len(m.connected_peers()) == 1, \
             f"expected 1 connected peer, got {m.connected_peers()}"
@@ -235,8 +250,8 @@ def test_deltachat_to_hivemind_roundtrip(monkeypatch):
         # --- inject a REAL inbound DeltaChat event ---------------------------
         # Drive the bridge bot's genuine ac_incoming_message handler with a
         # fake inbound deltachat Message. This calls handle_utterance, which the
-        # bridge wired to handle_delta_utterance -> emit_mycroft. The outbound
-        # reply is captured on this chat's send_text.
+        # bridge wired to _on_delta_utterance -> client.emit_mycroft (scheduled
+        # onto the bridge loop). The outbound reply is captured on send_text.
         chat = _CapturingChat()
         inbound = _make_inbound_message(inbound_text, user_addr, chat)
         bot.ac_incoming_message(inbound)
@@ -270,7 +285,7 @@ def test_deltachat_to_hivemind_roundtrip(monkeypatch):
         b.stop_all()
 
 
-def test_unanswered_utterance_sends_nothing(monkeypatch):
+def test_unanswered_utterance_sends_nothing():
     """If the hub agent never answers, the bridge sends no DeltaChat reply.
 
     Guards against a false-positive where the assertion would pass on stale
@@ -278,19 +293,18 @@ def test_unanswered_utterance_sends_nothing(monkeypatch):
     """
     b = TopologyBuilder()
     m = b.add_master("M0", use_loopback=True)
-    m.register_satellite("dc-key2", password="dc-password2",
+    m.register_satellite("dc-key2", password="dc-Xk39vLq2mN8w-e2e-2",
                          allowed_types=["recognizer_loop:utterance"])
     b.start_all()
 
     bridge = None
     try:
         bot = DeltaChatBot(email="bot@example.org", password="hunter2")
-        monkeypatch.setattr("hm_deltachat_bridge.DeltaChatBot",
-                            lambda *a, **k: bot)
         bot.start = MagicMock()
 
-        bridge = _make_bridge(m.network_protocol.url, "dc-key2", "dc-password2", bot)
-        bridge.wait_for_handshake(timeout=10)
+        bridge = _BridgeRunner(m.network_protocol.url, "dc-key2",
+                               "dc-Xk39vLq2mN8w-e2e-2", bot)
+        bridge.start(timeout=10)
         time.sleep(1)
 
         chat = _CapturingChat()

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,268 @@
+"""Tests for HiveMindDeltaChatBridge.
+
+We don't stand up a real DeltaChat account or a real HiveMind hub:
+
+- The HiveMind client is replaced with ``AsyncFakeHiveMessageBus`` from
+  ``hivemind-bus-client`` so emit + on_mycroft + close behave exactly
+  like the real async client without a WebSocket.
+- The DeltaChat bot is replaced with ``_StubBot`` so we can directly
+  fire the "incoming utterance" callback from a test, and assert that
+  outbound speak messages were routed back to it.
+
+Together these exercise the bridge's actual job: wire the two clients
+together correctly, with the threading bridge (deltachat thread →
+asyncio loop) intact.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import unittest
+from unittest.mock import MagicMock
+
+from hivemind_bus_client.fakebus import AsyncFakeHiveMessageBus
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from ovos_bus_client.message import Message
+
+from hm_deltachat_bridge import HiveMindDeltaChatBridge
+
+
+class _StubBot:
+    """Stand-in for DeltaChatBot. Records ``speak`` calls; exposes a hook
+    to simulate an incoming chat message from any thread."""
+
+    def __init__(self):
+        self.handle_utterance = None  # set by bridge.start()
+        self.started = False
+        self.stopped = False
+        self.spoken: list[tuple[str, str]] = []  # (utterance, addr)
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+    def speak(self, utterance: str, addr: str):
+        self.spoken.append((utterance, addr))
+
+    def fire_incoming(self, utterance: str, addr: str, *, from_thread: bool = False):
+        """Simulate a deltachat 'message arrived' callback.
+
+        When ``from_thread=True``, fires the callback from a separate
+        thread so the bridge's ``asyncio.run_coroutine_threadsafe`` path
+        is exercised exactly as in production.
+        """
+        cb = self.handle_utterance
+        assert cb is not None, "bridge.start() not called yet"
+        if from_thread:
+            done = threading.Event()
+
+            def _go():
+                cb(utterance, addr)
+                done.set()
+
+            threading.Thread(target=_go, daemon=True).start()
+            done.wait(timeout=2)
+        else:
+            cb(utterance, addr)
+
+
+def _make_bridge() -> HiveMindDeltaChatBridge:
+    return HiveMindDeltaChatBridge(
+        client=AsyncFakeHiveMessageBus(site_id="test-deltachat"),
+        bot=_StubBot(),
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestLifecycle(unittest.TestCase):
+    def test_start_idempotent(self):
+        bridge = _make_bridge()
+
+        async def scenario():
+            await bridge.start()
+            self.assertTrue(bridge._started)
+            self.assertTrue(bridge.bot.started)
+            self.assertTrue(bridge.client.connected_event.is_set())
+            # second start is a no-op
+            await bridge.start()
+            await bridge.stop()
+
+        _run(scenario())
+        self.assertTrue(bridge.bot.stopped)
+        self.assertFalse(bridge.client.connected_event.is_set())
+
+    def test_stop_idempotent_and_before_start(self):
+        bridge = _make_bridge()
+        # stop before start is a no-op
+        _run(bridge.stop())
+        self.assertFalse(bridge.bot.stopped)
+
+
+class TestDeltachatToHivemind(unittest.TestCase):
+    def test_incoming_dm_is_forwarded_as_utterance(self):
+        bridge = _make_bridge()
+
+        async def scenario():
+            await bridge.start()
+            try:
+                # callback fires from the deltachat lib thread in production —
+                # use the from_thread path to match
+                bridge.bot.fire_incoming(
+                    "what time is it", "alice@example.com",
+                    from_thread=True,
+                )
+                # give the loop a tick to pick up the scheduled coroutine
+                await asyncio.sleep(0.05)
+            finally:
+                await bridge.stop()
+
+        _run(scenario())
+
+        emitted = bridge.client.emitted
+        self.assertEqual(len(emitted), 1)
+        env = emitted[0]
+        self.assertEqual(env.msg_type, HiveMessageType.BUS)
+        self.assertEqual(env.payload.msg_type, "recognizer_loop:utterance")
+        self.assertEqual(env.payload.data["utterances"], ["what time is it"])
+        self.assertEqual(env.payload.context["deltachat_addr"], "alice@example.com")
+
+    def test_incoming_from_thread_uses_run_coroutine_threadsafe(self):
+        """Exercise the real deltachat-thread -> asyncio-loop bridge path."""
+        bridge = _make_bridge()
+
+        async def scenario():
+            await bridge.start()
+            try:
+                bridge.bot.fire_incoming(
+                    "hello from another thread",
+                    "bob@example.com",
+                    from_thread=True,
+                )
+                # Give the loop a moment to pick up the scheduled coroutine.
+                # asyncio.sleep(0.05) is enough — run_coroutine_threadsafe is
+                # essentially loop.call_soon_threadsafe.
+                await asyncio.sleep(0.05)
+            finally:
+                await bridge.stop()
+
+        _run(scenario())
+
+        emitted = bridge.client.emitted
+        self.assertEqual(len(emitted), 1)
+        self.assertEqual(
+            emitted[0].payload.data["utterances"],
+            ["hello from another thread"],
+        )
+
+    def test_callback_before_start_drops_message(self):
+        bridge = _make_bridge()
+        # don't call start(); manually fire the callback. It must not crash.
+        bridge._on_delta_utterance("orphan", "ghost@example.com")
+        self.assertEqual(bridge.client.emitted, [])
+
+
+class TestHivemindToDeltachat(unittest.TestCase):
+    def test_speak_is_routed_to_bot_speak(self):
+        bridge = _make_bridge()
+
+        async def scenario():
+            await bridge.start()
+            try:
+                # Simulate a HiveMind reply: a BUS HiveMessage carrying a
+                # speak payload addressed to the original deltachat sender.
+                speak = Message(
+                    "speak",
+                    {"utterance": "it is 9am"},
+                    {"deltachat_addr": "alice@example.com"},
+                )
+                # The bridge listens on the internal Mycroft bus via on_mycroft;
+                # AsyncFakeHiveMessageBus.emit() dispatches Mycroft messages to
+                # the internal bus before the hive emitter, so emitting the BUS
+                # envelope drives the same code path as a real reply.
+                await bridge.client.emit(speak)
+            finally:
+                await bridge.stop()
+
+        _run(scenario())
+        self.assertEqual(
+            bridge.bot.spoken,
+            [("it is 9am", "alice@example.com")],
+        )
+
+    def test_speak_without_addr_is_logged_and_dropped(self):
+        bridge = _make_bridge()
+
+        async def scenario():
+            await bridge.start()
+            try:
+                # speak with no deltachat_addr — bridge must log + ignore
+                speak = Message("speak", {"utterance": "orphan reply"})
+                await bridge.client.emit(speak)
+            finally:
+                await bridge.stop()
+
+        _run(scenario())
+        self.assertEqual(bridge.bot.spoken, [])
+
+    def test_bot_speak_exception_does_not_crash_handler(self):
+        bridge = _make_bridge()
+        bridge.bot.speak = MagicMock(side_effect=RuntimeError("boom"))
+
+        async def scenario():
+            await bridge.start()
+            try:
+                await bridge.client.emit(
+                    Message("speak",
+                            {"utterance": "boom"},
+                            {"deltachat_addr": "x@y"})
+                )
+            finally:
+                await bridge.stop()
+
+        # must not raise
+        _run(scenario())
+
+
+class TestRoundTrip(unittest.TestCase):
+    def test_dm_in_speak_out_flow(self):
+        bridge = _make_bridge()
+
+        async def scenario():
+            await bridge.start()
+            try:
+                # 1. user sends a chat message (from deltachat lib thread —
+                # exercise the real run_coroutine_threadsafe path)
+                bridge.bot.fire_incoming(
+                    "what time is it", "alice@example.com",
+                    from_thread=True,
+                )
+                await asyncio.sleep(0.05)
+
+                # bridge forwarded as recognizer_loop:utterance
+                self.assertEqual(len(bridge.client.emitted), 1)
+
+                # 2. HiveMind hub answers with a speak
+                await bridge.client.emit(
+                    Message("speak",
+                            {"utterance": "it is 9am"},
+                            {"deltachat_addr": "alice@example.com"})
+                )
+
+                # bridge sent it back to deltachat
+                self.assertEqual(
+                    bridge.bot.spoken,
+                    [("it is 9am", "alice@example.com")],
+                )
+            finally:
+                await bridge.stop()
+
+        _run(scenario())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,7 +2,8 @@
 with the DeltaChat account and the HiveMind bus connection mocked out so no live
 DeltaChat/HiveMind connection is ever opened.
 """
-from unittest.mock import MagicMock, patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import hm_deltachat_bridge
 from hm_deltachat_bridge import HiveMindDeltaChatBridge, __version__
@@ -21,17 +22,49 @@ def test_console_entrypoint_importable():
     assert callable(launch_bot)
 
 
-def test_construct_bridge_with_mocked_bus():
-    """Construct the bridge without touching DeltaChat or a HiveMind server.
+def _fake_client():
+    """An object exposing the AsyncHiveMessageBusClient surface the bridge uses."""
+    client = MagicMock()
+    client.connect = AsyncMock()
+    client.close = AsyncMock()
+    client.emit_mycroft = AsyncMock()
+    return client
 
-    HiveMindDeltaChatBridge.__init__ builds a DeltaChatBot (live email account),
-    starts it, then calls the HiveMessageBusClient initializer and connect(). We
-    patch the bot and the bus-client side effects so nothing reaches the network.
+
+def test_construct_and_start_bridge_with_mocked_bus():
+    """Construct + start/stop the bridge without touching DeltaChat or a HiveMind server.
+
+    HiveMindDeltaChatBridge composes a DeltaChatBot (live email account) and an
+    AsyncHiveMessageBusClient. Both are injected as mocks so nothing reaches the
+    network.
     """
+    bot_instance = MagicMock()
+    client = _fake_client()
+
+    bridge = HiveMindDeltaChatBridge(bot=bot_instance, client=client)
+
+    async def scenario():
+        await bridge.start()
+        # the bot was started and the bridge wired its delta handler onto it
+        bot_instance.start.assert_called_once()
+        assert bot_instance.handle_utterance == bridge._on_delta_utterance
+        # connect() was invoked (mocked, no socket opened) and the speak
+        # handler registered
+        client.connect.assert_awaited_once()
+        client.on_mycroft.assert_called_once_with("speak", bridge._on_speak)
+
+        # stop() delegates to the bot and closes the HiveMind client
+        await bridge.stop()
+        bot_instance.stop.assert_called_once()
+        client.close.assert_awaited_once()
+
+    asyncio.run(scenario())
+
+
+def test_default_construction_builds_bot_and_client():
+    """Without DI the bridge builds a DeltaChatBot and an AsyncHiveMessageBusClient."""
     with patch("hm_deltachat_bridge.DeltaChatBot") as MockBot, \
-            patch.object(HiveMindDeltaChatBridge, "connect", return_value=None) as mock_connect, \
-            patch.object(HiveMindDeltaChatBridge, "on_mycroft", return_value=None), \
-            patch("hivemind_bus_client.client.HiveMessageBusClient.__init__", return_value=None):
+            patch("hm_deltachat_bridge.AsyncHiveMessageBusClient") as MockClient:
         bot_instance = MagicMock()
         MockBot.return_value = bot_instance
 
@@ -44,34 +77,38 @@ def test_construct_bridge_with_mocked_bus():
             password="testpassword",
         )
 
-        # the bot was created and started, but no live account was configured
-        MockBot.assert_called_once_with("bot@example.org", "hunter2")
-        bot_instance.start.assert_called_once()
-        # the bridge wired its delta handler onto the bot
-        assert bot_instance.handle_utterance == bridge.handle_delta_utterance
-        # connect() was invoked (mocked, no socket opened)
-        mock_connect.assert_called_once()
+        MockBot.assert_called_once_with(email="bot@example.org",
+                                        password="hunter2")
+        MockClient.assert_called_once()
+        kwargs = MockClient.call_args.kwargs
+        assert kwargs["key"] == "testkey"
+        assert kwargs["host"] == "ws://127.0.0.1"
+        assert kwargs["port"] == 5678
+        assert kwargs["password"] == "testpassword"
+        # the bot is created but NOT started at construction time
+        bot_instance.start.assert_not_called()
+        assert bridge.bot is bot_instance
 
-        # stop() delegates to the bot
-        bridge.stop()
-        bot_instance.stop.assert_called_once()
 
+def test_on_delta_utterance_emits_mycroft():
+    """_on_delta_utterance should emit a recognizer_loop:utterance carrying the addr."""
+    client = _fake_client()
+    bridge = HiveMindDeltaChatBridge(bot=MagicMock(), client=client)
 
-def test_handle_delta_utterance_emits_mycroft():
-    """handle_delta_utterance should emit a recognizer_loop:utterance carrying the addr."""
-    with patch("hm_deltachat_bridge.DeltaChatBot") as MockBot, \
-            patch.object(HiveMindDeltaChatBridge, "connect", return_value=None), \
-            patch.object(HiveMindDeltaChatBridge, "on_mycroft", return_value=None), \
-            patch("hivemind_bus_client.client.HiveMessageBusClient.__init__", return_value=None):
-        MockBot.return_value = MagicMock()
-        bridge = HiveMindDeltaChatBridge(
-            email="bot@example.org", email_password="hunter2",
-            key="k", host="ws://127.0.0.1", port=5678, password="p",
-        )
-        with patch.object(bridge, "emit_mycroft") as mock_emit:
-            bridge.handle_delta_utterance("hello world", "user@example.org")
-            mock_emit.assert_called_once()
-            msg = mock_emit.call_args.args[0]
-            assert msg.msg_type == "recognizer_loop:utterance"
-            assert msg.data["utterances"] == ["hello world"]
-            assert msg.context["deltachat_addr"] == "user@example.org"
+    async def scenario():
+        await bridge.start()
+        bridge._on_delta_utterance("hello world", "user@example.org")
+        # the emit is scheduled with run_coroutine_threadsafe; yield to the
+        # loop until it runs
+        for _ in range(50):
+            if client.emit_mycroft.await_count:
+                break
+            await asyncio.sleep(0.01)
+        client.emit_mycroft.assert_awaited_once()
+        msg = client.emit_mycroft.await_args.args[0]
+        assert msg.msg_type == "recognizer_loop:utterance"
+        assert msg.data["utterances"] == ["hello world"]
+        assert msg.context["deltachat_addr"] == "user@example.org"
+        await bridge.stop()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary

Migrates `HiveMind-deltachat-bridge` from `HiveMessageBusClient` (sync, daemon-thread based) to `AsyncHiveMessageBusClient` (asyncio, shipped in `hivemind-bus-client` 0.8.0 behind the `[async]` extra). This is **Step 3** of the OVOS / HiveMind async-adoption plan and the **first real consumer** of `AsyncHiveMessageBusClient` in production.

### Before / after threading

| | Before | After |
|---|---|---|
| HiveMind side | sync `HiveMessageBusClient.run_in_thread()` (daemon thread) | `AsyncHiveMessageBusClient` on the application's asyncio loop |
| DeltaChat side | `DeltaChatBot(threading.Thread)` | `DeltaChatBot(threading.Thread)` — unchanged; the classic `deltachat` package is callback-based, not asyncio-aware |
| Cross-side seam | monkey-patched callback + two threads sharing state | one explicit `asyncio.run_coroutine_threadsafe` at one well-defined seam |
| Thread count | 2 daemon threads in the bridge process | 1 (deltachat lib's own) |

Migrating fully off threads would require switching to `deltachat-rpc-client` (async-first, separate Rust RPC server) — that's a larger, deployment-affecting change deferred to a follow-up per the plan.

## What changed

### `hm_deltachat_bridge/__init__.py`

`HiveMindDeltaChatBridge` is now a **composition** instead of a subclass of `HiveMessageBusClient`. It holds an `AsyncHiveMessageBusClient` and a `DeltaChatBot`, exposes:

- `async start()` — sets `handle_utterance` on the bot, starts the bot thread, connects the HiveMind client, registers the `speak` handler. Idempotent.
- `async stop()` — removes the handler, stops the bot, closes the client. Idempotent, safe before start.

Two thread-crossing seams, both explicit:

- **deltachat → HiveMind**: `_on_delta_utterance` fires on the deltachat lib's thread; it uses `asyncio.run_coroutine_threadsafe(self.client.emit_mycroft(...), self._loop)` to schedule the async emit onto the bridge's event loop.
- **HiveMind → deltachat**: `_on_speak` runs on the asyncio receive task. It calls `self.bot.speak(...)` directly — the deltachat library is thread-safe for `chat.send_text`.

Constructor accepts optional `client` and `bot` for DI in tests.

### `hm_deltachat_bridge/__main__.py`

Now `asyncio.run(_amain(...))`. Adds `loop.add_signal_handler(SIGINT/SIGTERM, stop_event.set)` for graceful shutdown, replacing the old `wait_for_exit_signal` call.

### `setup.py`

- Bump version: `0.0.2` → `0.1.0` (signals the breaking change below).
- Require `hivemind_bus_client[async]>=0.8.0` instead of `hivemind_bus_client`.
- Fix legacy `console_scripts` typo: `deltachat_bridge.__main__:launch_bot` (never importable — wrong package name) → `hm_deltachat_bridge.__main__:launch_bot`.
- Add `[test]` extra.

### `.gitignore` (new)

Standard Python gitignore. The repo had no `.gitignore` so the first PR commit accidentally tracked `__pycache__/`; fixed in this PR.

## Tests — `tests/test_bridge.py` (9 tests)

Uses `AsyncFakeHiveMessageBus` from `hivemind_bus_client.fakebus` (released in the sibling PR, 0.8.0a1+) for the HiveMind side, and a minimal `_StubBot` for the deltachat side. **No real DeltaChat account or HiveMind hub needed**; tests run in <1s.

- **Lifecycle**: `start`/`stop` idempotency, `stop` before `start` is safe.
- **Deltachat → HiveMind**: incoming DM forwarded as `recognizer_loop:utterance` via `run_coroutine_threadsafe` — and importantly, fired from a real worker thread to exercise the production code path; orphan callback (before `start`) is dropped safely.
- **HiveMind → Deltachat**: `speak` with `deltachat_addr` routed to `bot.speak`; `speak` without addr is logged and dropped; `bot.speak` exceptions are logged but don't crash the handler.
- **Round-trip**: full DM-in / speak-out flow.

```
9 passed in 0.40s
```

## Breaking changes

1. **`HiveMindDeltaChatBridge` no longer subclasses `HiveMessageBusClient`.** Anything that called methods on the bridge instance directly (e.g. `node.emit()`, `node.on_mycroft(...)`) now goes through `node.client` (`node.client.emit(...)`, `node.client.on_mycroft(...)`). The bridge instance is no longer a bus client; it owns one.
2. **Sync API is gone.** `start()` and `stop()` are coroutines. The CLI invocation is unchanged (`hm-deltachat-bridge ...`).
3. **Console-script entry fix.** The previous `deltachat_bridge.__main__:launch_bot` could never have worked (the package is `hm_deltachat_bridge`); now `hm_deltachat_bridge.__main__:launch_bot`. If anything was depending on the broken name, it never ran anyway.

## Test plan

- [x] 9 unit tests pass (bridge.start / stop / DM → HM / HM → DM / round-trip).
- [ ] CI green.
- [ ] Manual: connect to a real DeltaChat email account + real HiveMind hub, send a chat, observe the HiveMind reply spoken back as a chat message. Force-disconnect HiveMind mid-session; observe reconnect.
- [ ] Force-disconnect DeltaChat (network drop); observe bridge stays alive and resumes when network returns.

## Refs

- This bridge depends on `hivemind-bus-client[async]>=0.8.0` (PR #115 in `hivemind-websocket-client`, released as 0.8.0a1).
- Tests depend on PR #117 (`AsyncFakeHiveMessageBus`) in the same repo, currently open.
- Follow-ups per the OVOS-async adoption plan: `HiveMind-matrix-bridge` migration (also uses `HiveMindSolver` — separate shape but similar story); `hivemind-ovos-agent-plugin` sidecar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The bridge now starts and stops asynchronously, with cleaner signal-based shutdown from the command line.
  * Incoming DeltaChat messages are forwarded more reliably, and HiveMind replies are routed back to the correct chat address.

* **Bug Fixes**
  * Improved handling for messages arriving before startup, missing routing details, and bot send errors.
  * Added safer cleanup so repeated stop calls do not cause issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->