### PR TITLE
docs: zero-to-hero README and docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,50 @@
+# Configuration & Credentials Reference
+
+The bridge needs two sets of credentials: one for the bot mailbox, one for the HiveMind hub.
+
+## DeltaChat (mailbox) credentials
+
+| Option | Meaning |
+| --- | --- |
+| `--email` | The bot's email address. This is the address users message to reach the hub. |
+| `--email-password` | The mailbox password (or app password where the provider requires one). |
+
+DeltaChat configures itself from the address and password: it discovers IMAP/SMTP settings for common providers automatically. A local account database is created in the system temp directory, keyed by the address.
+
+### Sender allowlist
+
+The underlying bot supports an `allowed_emails` allowlist. When empty (the default) it accepts messages from any sender. There is no CLI flag for it yet; set it programmatically on `DeltaChatBot` if you need to restrict access.
+
+## HiveMind credentials
+
+| Option | Meaning | Default |
+| --- | --- | --- |
+| `--key` | HiveMind access key, from `hivemind-core add-client`. | read from identity file |
+| `--password` | HiveMind password, from `hivemind-core add-client`. | read from identity file |
+| `--host` | Hub host. A `ws://` prefix is added automatically if you omit the scheme. | read from identity file |
+| `--port` | Hub port. | `5678` |
+
+### Identity file
+
+When `--key/--password/--host` are not passed, the bridge reads them from the stored `NodeIdentity`. Set it once:
+
+```bash
+hivemind-client set-identity \
+  --key "your-access-key" \
+  --password "your-password" \
+  --host "ws://192.168.1.100"
+```
+
+If neither the options nor a stored identity supply a key, password, and host, the bridge raises:
+
+```
+NodeIdentity not set, please pass key/password/host or call 'hivemind-client set-identity'
+```
+
+## Reply routing
+
+Outbound utterances are tagged with the sender's address (`deltachat_addr`) in the message context. The hub echoes that context on its `speak` reply, and the bridge uses it to deliver the answer to the originating chat. A `speak` reply that arrives without `deltachat_addr` is logged and dropped.
+
+## Encryption
+
+The HiveMind connection is authenticated and encrypted by the protocol layer (handled by `hivemind-bus-client`). DeltaChat itself provides end-to-end encryption (Autocrypt) for the email transport between users and the bot mailbox.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,70 @@
+# Examples
+
+## Run with stored identity
+
+Store the HiveMind identity once, then run with only the mailbox login:
+
+```bash
+hivemind-client set-identity --key KEY --password PASS --host ws://192.168.1.100
+hm-deltachat-bridge --email bot@example.com --email-password "mailbox-password"
+```
+
+## Run with all credentials inline
+
+```bash
+hm-deltachat-bridge \
+  --email bot@example.com \
+  --email-password "mailbox-password" \
+  --key "your-access-key" \
+  --password "your-password" \
+  --host "192.168.1.100" \
+  --port 5678
+```
+
+A `ws://` prefix is added to `--host` automatically when no scheme is given.
+
+## A conversation
+
+A user opens a chat with `bot@example.com` from any DeltaChat app:
+
+```
+user> what time is it?
+bot>  It is half past three.
+
+user> set a timer for five minutes
+bot>  Timer set for five minutes.
+```
+
+Each reply is delivered to the chat the message came from.
+
+## Embed the bridge in your own program
+
+`HiveMindDeltaChatBridge` is an asyncio object. The hub and DeltaChat clients can be injected for testing or customization:
+
+```python
+import asyncio
+from hm_deltachat_bridge import HiveMindDeltaChatBridge
+
+async def main():
+    bridge = HiveMindDeltaChatBridge(
+        email="bot@example.com",
+        email_password="mailbox-password",
+        key="your-access-key",
+        password="your-password",
+        host="ws://192.168.1.100",
+        port=5678,
+    )
+    await bridge.start()
+    try:
+        await asyncio.Event().wait()  # run until cancelled
+    finally:
+        await bridge.stop()
+
+asyncio.run(main())
+```
+
+To restrict who may message the bot, set the allowlist on the underlying bot before `start()`:
+
+```python
+bridge.bot.allowed_emails = ["alice@example.com", "bob@example.com"]
+```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,81 @@
+# Setup Walkthrough
+
+From nothing to a working DeltaChat chatbot backed by a HiveMind hub.
+
+## How the bridge fits together
+
+The bridge is a HiveMind satellite with two connections:
+
+- **To DeltaChat** — it logs into the bot's mailbox (IMAP/SMTP) and watches for incoming messages.
+- **To the HiveMind hub** — it authenticates with a HiveMind access key and password and exchanges encrypted protocol messages.
+
+Each inbound chat message is tagged with the sender's address and sent to the hub as a `recognizer_loop:utterance`. The hub's `speak` reply carries that address back, so the bridge routes the answer to the right chat.
+
+```
+DeltaChat (email)  ⇄  bridge  ⇄  hivemind-core hub  ⇄  OVOS pipeline / skills
+```
+
+## Step 1 — Stand up a HiveMind hub
+
+Install and run [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core):
+
+```bash
+pip install hivemind-core
+hivemind-core listen
+```
+
+The hub listens on port `5678` by default.
+
+## Step 2 — Register the bridge as a client
+
+On the hub machine:
+
+```bash
+hivemind-core add-client --name deltachat-bridge \
+  --access-key "your-access-key" --password "your-password"
+```
+
+Keep the access key and password. List clients with `hivemind-core list-clients`.
+
+## Step 3 — Prepare the bot mailbox
+
+1. Create or pick an email account for the bot (any IMAP/SMTP provider).
+2. Note the address and password. Where the provider enforces app passwords (for example for IMAP access), generate one.
+3. The bot's address is what users message to reach the hub.
+
+## Step 4 — Install the native DeltaChat library
+
+The `deltachat` Python package binds to native `libdeltachat` / `deltachat-core`. Install it via your platform package manager or from the [DeltaChat core releases](https://github.com/deltachat/deltachat-core-rust) before installing the bridge.
+
+## Step 5 — Install the bridge
+
+```bash
+pip install HiveMind-deltachat-bridge
+```
+
+## Step 6 — Provide the HiveMind credentials
+
+Store an identity once:
+
+```bash
+hivemind-client set-identity \
+  --key "your-access-key" \
+  --password "your-password" \
+  --host "ws://192.168.1.100"
+```
+
+or pass `--key/--password/--host` on each run.
+
+## Step 7 — Run
+
+```bash
+hm-deltachat-bridge \
+  --email "bot@example.com" \
+  --email-password "mailbox-password"
+```
+
+The bridge logs `connected to DeltaChat` and `connected to HiveMind`.
+
+## Step 8 — Talk to it
+
+From any DeltaChat client, start a chat with `bot@example.com` and send a message. The bridge forwards it to the hub and replies with the spoken answer.

--- a/readme.md
+++ b/readme.md
@@ -1,26 +1,94 @@
-# HiveMind - DeltaChat Bridge
+# HiveMind DeltaChat Bridge
 
-[DeltaChat](https://delta.chat/en/) bridge for the [HiveMind](https://github.com/OpenJarbas/HiveMind-core)
+Relay a [DeltaChat](https://delta.chat/en/) account to a [HiveMind](https://github.com/JarbasHiveMind/HiveMind-core) hub.
 
-![logo](./deltachat.png)
-![img.png](img.png)
+[DeltaChat](https://delta.chat) is an end-to-end-encrypted chat that runs over ordinary email. This bridge is a HiveMind **satellite** whose input and output are DeltaChat messages instead of a microphone. Each incoming chat message becomes an utterance sent to the hub; the hub's spoken reply is delivered back to the sender's chat. Any HiveMind hub (and the OVOS skills behind it) becomes reachable as an email-based chatbot.
+
+```
+DeltaChat (email)  ⇄  HiveMind-deltachat-bridge  ⇄  HiveMind hub (hivemind-core)  ⇄  OVOS skills
+```
+
+## Prerequisites
+
+- A running **HiveMind hub** ([hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core)) reachable over the network.
+- A **HiveMind access key + password** for this bridge, issued by the hub with `hivemind-core add-client`.
+- An **email account** for the bot (address + password). DeltaChat works with any IMAP/SMTP mailbox; the address is what users message to talk to the hub.
+- The native **`libdeltachat` / `deltachat-core`** library installed on the system — the `deltachat` Python package binds to it.
 
 ## Install
 
 ```bash
-$ pip install HiveMind-deltachat-bridge
+pip install HiveMind-deltachat-bridge
 ```
-## Usage
+
+Or from a checkout:
 
 ```bash
-$ hm-deltachat-bridge --help
-
-Options:
-  --email TEXT           deltachat email
-  --email-password TEXT  deltachat email password
-  --key TEXT             HiveMind access key (default read from identity file)
-  --password TEXT        HiveMind password (default read from identity file)
-  --host TEXT            HiveMind host (default read from identity file)
-  --port INTEGER         HiveMind port number (default: 5678)
-  --help                 Show this message and exit.
+git clone https://github.com/JarbasHiveMind/HiveMind-deltachat-bridge
+cd HiveMind-deltachat-bridge
+pip install .
 ```
+
+This installs the `hm-deltachat-bridge` console command.
+
+## Quickstart
+
+**1. Register the bridge on the hub** (run where `hivemind-core` is installed):
+
+```bash
+hivemind-core add-client --name deltachat-bridge \
+  --access-key "your-access-key" --password "your-password"
+```
+
+**2. Store the HiveMind credentials** so they are read automatically:
+
+```bash
+hivemind-client set-identity \
+  --key "your-access-key" \
+  --password "your-password" \
+  --host "ws://192.168.1.100"
+```
+
+(`set-identity` ships with `hivemind-bus-client`, a dependency of this bridge.) Alternatively, pass `--key/--password/--host` on every run.
+
+**3. Run the bridge** with the bot's email login:
+
+```bash
+hm-deltachat-bridge \
+  --email "bot@example.com" \
+  --email-password "mailbox-password"
+```
+
+**4. Send a message.** From any DeltaChat app (or plain email), message `bot@example.com`:
+
+```
+what time is it?
+```
+
+The bridge forwards the message to the hub, waits for the `speak` reply, and answers in the same chat.
+
+## Configuration
+
+`hm-deltachat-bridge` options:
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `--email` | Bot mailbox address | — |
+| `--email-password` | Bot mailbox password | — |
+| `--key` | HiveMind access key | read from identity file |
+| `--password` | HiveMind password | read from identity file |
+| `--host` | HiveMind host (a `ws://` prefix is added if no scheme) | read from identity file |
+| `--port` | HiveMind port | `5678` |
+
+When `--key/--password/--host` are omitted they are read from the stored `NodeIdentity`. If none are available the bridge exits pointing you at `hivemind-client set-identity`.
+
+## Troubleshooting
+
+- **`NodeIdentity not set`** — run `hivemind-client set-identity`, or pass `--key/--password/--host`.
+- **No reply to messages** — confirm the hub is reachable and the access key is authorized (`hivemind-core list-clients`), and that an OVOS pipeline produces spoken answers.
+- **Mailbox login fails** — verify IMAP/SMTP is enabled for the bot mailbox and the password is an app password where the provider requires one.
+- **`ImportError` on `deltachat`** — install the native `libdeltachat` / `deltachat-core` for your platform.
+
+## Documentation
+
+See [`docs/`](docs/) for a full setup walkthrough, a credential reference, and worked examples.


### PR DESCRIPTION
Brings the README and `docs/` to zero-to-hero quality.

## What this adds
- **README** — tagline, where the bridge sits (satellite relaying a DeltaChat account to a hivemind-core hub), prerequisites (bot mailbox, native libdeltachat, HiveMind access key), install, quickstart, configuration table, troubleshooting.
- **docs/setup.md** — end-to-end walkthrough from hub to first message.
- **docs/configuration.md** — mailbox + HiveMind credential reference, sender allowlist, reply routing via `deltachat_addr`, encryption notes.
- **docs/examples.md** — stored-identity vs inline runs, a sample conversation, embedding `HiveMindDeltaChatBridge` and setting an allowlist.

Docs only — no code, version, or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)