### PR TITLE
test: hivescope e2e + CI

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -2,9 +2,9 @@ name: E2E Tests
 
 # HiveMind-side end-to-end tests (tests/e2e/). These boot a REAL hivemind-core
 # hub (via hivescope's loopback WebSocket harness) and drive the REAL bridge
-# against it, mocking only the DeltaChat transport. They need hivescope, which
-# is unreleased — it is pulled from its feature branch with --pre (the whole
-# hivemind-core stack is currently alpha/prerelease) via pre_install_pip.
+# against it, mocking only the DeltaChat transport. hivescope is published on
+# PyPI; it and the 2.x hivemind-core stack resolve from the prerelease floors
+# in the [e2e] extra (PEP 440) — no --pre, no custom pip steps, no git pins.
 #
 # The live DeltaChat transport test (tests/e2e/test_deltachat_live.py) skips
 # cleanly unless DELTACHAT_ADDR/DELTACHAT_PASSWORD are present, so it is a no-op
@@ -19,12 +19,6 @@ jobs:
   e2e:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
     with:
-      python_versions: '["3.11"]'
-      # hivescope (+ its alpha hivemind-core stack) from the loopback-whitelist
-      # branch, installed BEFORE the package build with --pre so the prerelease
-      # dependency graph resolves. The spec is spaceless on purpose: the reusable
-      # workflow expands pre_install_pip *unquoted* into `pip install ...`, so any
-      # inner space (e.g. "hivescope @ git+...") would be word-split and break.
-      pre_install_pip: '--pre hivescope@git+https://github.com/JarbasHiveMind/hivescope.git@fix/loopback-whitelist-only-connection'
-      install_extras: 'test'
+      python_versions: '["3.10", "3.11", "3.12", "3.13"]'
+      install_extras: 'e2e'
       test_path: 'tests/e2e/'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,23 @@ dynamic = ["version", "dependencies"]
 
 [project.optional-dependencies]
 test = ["pytest"]
+# e2e drives the bridge against a REAL hivemind-core hub booted in-process by
+# hivescope (loopback WebSocket); only the DeltaChat transport is mocked. The
+# prerelease floors below let a plain `pip install -e .[e2e]` resolve the 2.x
+# hivemind-core stack with no --pre (PEP 440: a prerelease floor opts that
+# package into prereleases). Flooring the plugin chain directly avoids pip
+# backtracking stable->prerelease across the large transitive graph.
+e2e = [
+    "pytest",
+    "hivescope>=0.5.2a1",
+    "ovos-bus-client>=2.0.0a3,<3.0.0",
+    "hivemind-core>=4.6.7a1",
+    "hivemind-plugin-manager>=0.8.0a1",
+    "hivemind-websocket-protocol>=0.2.1a1",
+    "hivemind-ovos-agent-plugin>=0.3.2a1",
+    "hivemind-json-db-plugin>=0.0.3a2",
+    "hivemind-sqlite-database>=0.4.0a2",
+]
 
 [project.urls]
 Homepage = "https://github.com/JarbasHiveMind/HiveMind-deltachat-bridge"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hivemind-bus-client>=0.9.0,<1.0.0
+hivemind-bus-client>=0.9.2a1,<1.0.0
 ovos-utils
 click
 deltachat


### PR DESCRIPTION
## What

Moves the HiveMind-side e2e suite onto the published `hivescope` package.

- `pyproject.toml`: new `[e2e]` extra — `hivescope>=0.5.2a1` plus prerelease floors for the 2.x hivemind-core stack (`hivemind-core`, plugin chain, `ovos-bus-client`) so a plain `pip install .[e2e]` resolves with no `--pre` and no git pins.
- `requirements.txt`: `hivemind-bus-client` floor raised to `0.9.2a1` (hivescope's own floor) so the runtime dep and the e2e stack resolve to one graph.
- `.github/workflows/e2e_tests.yml`: drops the `pre_install_pip` git-branch install of hivescope; installs the `e2e` extra instead and widens the matrix to 3.10–3.13.

## What the e2e exercises

`tests/e2e/test_bridge_hivemind_e2e.py` (already on dev) boots a REAL hivemind-core hub via hivescope's loopback WebSocket and drives the production bridge end to end: inbound DeltaChat message → `handle_delta_utterance` → `recognizer_loop:utterance` over a real WebSocket → hub agent bus responder → `speak` routed back → captured outbound `chat.send_text`. Only the DeltaChat transport is mocked.

## Verified

Fresh venv, `pip install -e .[test,e2e]`, `pytest tests/`: 6 passed, 2 skipped (live-DeltaChat tests, credential-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)