### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/docs/accounts-and-chatmail.md
+++ b/docs/accounts-and-chatmail.md
@@ -1,4 +1,4 @@
-# Accounts & chatmail — running the DeltaChat bridge
+# Accounts & chatmail: running the DeltaChat bridge
 
 DeltaChat is end-to-end-encrypted chat that runs over **ordinary email**, so this
 bridge logs into a mailbox (IMAP to receive, SMTP to send) and relays each message
@@ -14,7 +14,7 @@ DeltaChat user  ⇄  bot's mailbox (IMAP/SMTP)  ⇄  hm-deltachat-bridge  ⇄  H
 
 You have three options. For a bot, **chatmail (Option A)** is recommended.
 
-### Option A — chatmail (recommended)
+### Option A: chatmail (recommended)
 
 **Chatmail** servers are minimal, privacy-first mail servers purpose-built for
 Delta Chat: instant signup (no name, phone, or recovery info), encryption
@@ -30,25 +30,25 @@ Ways to provision a chatmail account:
    You can also scan a chatmail invite QR or open a `DCACCOUNT:https://<server>/new`
    link.
 2. **Programmatically.** A chatmail server hands out fresh accounts at
-   `https://<server>/new`; the Delta Chat core can self-provision one from a
+   `https://<server>/new`. The Delta Chat core can self-provision one from a
    `dcaccount:` / `DCACCOUNT:` URL on first configure.
 3. **Self-host.** Run the chatmail relay server
    ([`chatmaild`](https://github.com/chatmail/relay)) on your own domain for a
    private chatmail instance you fully control.
 
 Public chatmail servers exist for testing / light use (for example
-`nine.testrun.org`); the current list is at <https://chatmail.at>. **For
-production, self-host or use a server you trust** — the bot's mailbox can read
+`nine.testrun.org`). The current list is at [chatmail.at](https://chatmail.at). **For
+production, self-host or use a server you trust.** The bot's mailbox can read
 every message users send it.
 
-### Option B — any IMAP/SMTP mailbox
+### Option B: any IMAP/SMTP mailbox
 
 Any standard email account works: Gmail (with IMAP enabled and an **app
 password**), Mailbox.org, Posteo, a self-hosted Dovecot/Postfix, etc. You supply
 the address + password and Delta Chat auto-detects the IMAP/SMTP servers for most
 providers.
 
-### Option C — self-hosted mail
+### Option C: self-hosted mail
 
 Run your own mail server (Postfix + Dovecot, or `chatmaild`) for full control and
 no third party in the loop.
@@ -93,12 +93,12 @@ from the identity file.
 ## 5. Talk to it
 
 Add the bot's **address** as a contact in any Delta Chat client and send it a
-message. Each incoming message becomes a `recognizer_loop:utterance` on the hub;
-the hub's spoken reply is delivered back to the sender's chat.
+message. Each incoming message becomes a `recognizer_loop:utterance` on the hub.
+The hub's spoken reply goes back to the sender's chat.
 
 ## Security notes
 
-- The **email password** and the **HiveMind password** are secrets — pass them via
+- The **email password** and the **HiveMind password** are secrets. Pass them via
   environment variables or a secrets manager, never in shell history or a
   committed file.
 - Chatmail enforces end-to-end encryption. With a generic mailbox, encryption
@@ -111,7 +111,7 @@ the hub's spoken reply is delivered back to the sender's chat.
 ## Testing (live e2e)
 
 `tests/e2e/test_deltachat_live.py` runs a **real** DeltaChat round-trip when you
-provide an account via environment variables; it skips cleanly when they're
+provide an account via environment variables. It skips cleanly when they are
 absent (the mocked HiveMind-side e2e always runs):
 
 ```bash
@@ -122,3 +122,6 @@ export DELTACHAT_PEER_ADDR="…"
 export DELTACHAT_PEER_PASSWORD="…"
 pytest tests/e2e/test_deltachat_live.py
 ```
+
+---
+[← Setup Walkthrough](setup.md) · [Home](../readme.md) · [Configuration →](configuration.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ DeltaChat configures itself from the address and password: it discovers IMAP/SMT
 
 ### Sender allowlist
 
-The underlying bot supports an `allowed_emails` allowlist. When empty (the default) it accepts messages from any sender. There is no CLI flag for it yet; set it programmatically on `DeltaChatBot` if you need to restrict access.
+The underlying bot supports an `allowed_emails` allowlist. When empty (the default) it accepts messages from any sender. There is no CLI flag for it yet. Set it programmatically on `DeltaChatBot` if you need to restrict access.
 
 ## HiveMind credentials
 
@@ -48,3 +48,6 @@ Outbound utterances are tagged with the sender's address (`deltachat_addr`) in t
 ## Encryption
 
 The HiveMind connection is authenticated and encrypted by the protocol layer (handled by `hivemind-bus-client`). DeltaChat itself provides end-to-end encryption (Autocrypt) for the email transport between users and the bot mailbox.
+
+---
+[← Accounts & chatmail](accounts-and-chatmail.md) · [Home](../readme.md) · [Examples →](examples.md)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -68,3 +68,6 @@ To restrict who may message the bot, set the allowlist on the underlying bot bef
 ```python
 bridge.bot.allowed_emails = ["alice@example.com", "bob@example.com"]
 ```
+
+---
+[← Configuration](configuration.md) · [Home](../readme.md)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,8 +6,8 @@ From nothing to a working DeltaChat chatbot backed by a HiveMind hub.
 
 The bridge is a HiveMind satellite with two connections:
 
-- **To DeltaChat** — it logs into the bot's mailbox (IMAP/SMTP) and watches for incoming messages. Need a mailbox? See [`accounts-and-chatmail.md`](accounts-and-chatmail.md) — a **chatmail** account is the quickest, bot-friendly option.
-- **To the HiveMind hub** — it authenticates with a HiveMind access key and password and exchanges encrypted protocol messages.
+- **To DeltaChat**: it logs into the bot's mailbox (IMAP/SMTP) and watches for incoming messages. Need a mailbox? See [`accounts-and-chatmail.md`](accounts-and-chatmail.md). A **chatmail** account is the quickest, bot-friendly option.
+- **To the HiveMind hub**: it authenticates with a HiveMind access key and password and exchanges encrypted protocol messages.
 
 Each inbound chat message is tagged with the sender's address and sent to the hub as a `recognizer_loop:utterance`. The hub's `speak` reply carries that address back, so the bridge routes the answer to the right chat.
 
@@ -15,7 +15,7 @@ Each inbound chat message is tagged with the sender's address and sent to the hu
 DeltaChat (email)  ⇄  bridge  ⇄  hivemind-core hub  ⇄  OVOS pipeline / skills
 ```
 
-## Step 1 — Stand up a HiveMind hub
+## Step 1: Stand up a HiveMind hub
 
 Install and run [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core):
 
@@ -26,7 +26,7 @@ hivemind-core listen
 
 The hub listens on port `5678` by default.
 
-## Step 2 — Register the bridge as a client
+## Step 2: Register the bridge as a client
 
 On the hub machine:
 
@@ -37,23 +37,23 @@ hivemind-core add-client --name deltachat-bridge \
 
 Keep the access key and password. List clients with `hivemind-core list-clients`.
 
-## Step 3 — Prepare the bot mailbox
+## Step 3: Prepare the bot mailbox
 
 1. Create or pick an email account for the bot (any IMAP/SMTP provider).
 2. Note the address and password. Where the provider enforces app passwords (for example for IMAP access), generate one.
 3. The bot's address is what users message to reach the hub.
 
-## Step 4 — Install the native DeltaChat library
+## Step 4: Install the native DeltaChat library
 
 The `deltachat` Python package binds to native `libdeltachat` / `deltachat-core`. Install it via your platform package manager or from the [DeltaChat core releases](https://github.com/deltachat/deltachat-core-rust) before installing the bridge.
 
-## Step 5 — Install the bridge
+## Step 5: Install the bridge
 
 ```bash
 pip install HiveMind-deltachat-bridge
 ```
 
-## Step 6 — Provide the HiveMind credentials
+## Step 6: Provide the HiveMind credentials
 
 Store an identity once:
 
@@ -66,7 +66,7 @@ hivemind-client set-identity \
 
 or pass `--key/--password/--host` on each run.
 
-## Step 7 — Run
+## Step 7: Run
 
 ```bash
 hm-deltachat-bridge \
@@ -76,6 +76,9 @@ hm-deltachat-bridge \
 
 The bridge logs `connected to DeltaChat` and `connected to HiveMind`.
 
-## Step 8 — Talk to it
+## Step 8: Talk to it
 
 From any DeltaChat client, start a chat with `bot@example.com` and send a message. The bridge forwards it to the hub and replies with the spoken answer.
+
+---
+[Home](../readme.md) · [Accounts & chatmail →](accounts-and-chatmail.md)

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Relay a [DeltaChat](https://delta.chat/en/) account to a [HiveMind](https://github.com/JarbasHiveMind/HiveMind-core) hub.
 
-[DeltaChat](https://delta.chat) is an end-to-end-encrypted chat that runs over ordinary email. This bridge is a HiveMind **satellite** whose input and output are DeltaChat messages instead of a microphone. Each incoming chat message becomes an utterance sent to the hub; the hub's spoken reply is delivered back to the sender's chat. Any HiveMind hub (and the OVOS skills behind it) becomes reachable as an email-based chatbot.
+[DeltaChat](https://delta.chat) is an end-to-end-encrypted chat that runs over ordinary email. This bridge is a HiveMind **satellite** whose input and output are DeltaChat messages instead of a microphone. Each incoming chat message becomes an utterance sent to the hub. The hub's spoken reply goes back to the sender's chat. Any HiveMind hub, and the OVOS skills behind it, becomes reachable as an email-based chatbot.
 
 ```
 DeltaChat (email)  ⇄  HiveMind-deltachat-bridge  ⇄  HiveMind hub (hivemind-core)  ⇄  OVOS skills
@@ -12,8 +12,8 @@ DeltaChat (email)  ⇄  HiveMind-deltachat-bridge  ⇄  HiveMind hub (hivemind-c
 
 - A running **HiveMind hub** ([hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core)) reachable over the network.
 - A **HiveMind access key + password** for this bridge, issued by the hub with `hivemind-core add-client`.
-- An **email account** for the bot (address + password). DeltaChat works with any IMAP/SMTP mailbox; the address is what users message to talk to the hub. The easiest option is a **chatmail** account (instant, bot-friendly) — see [`docs/accounts-and-chatmail.md`](docs/accounts-and-chatmail.md) for how to get one and the full operator walkthrough.
-- The native **`libdeltachat` / `deltachat-core`** library installed on the system — the `deltachat` Python package binds to it.
+- An **email account** for the bot (address + password). DeltaChat works with any IMAP/SMTP mailbox. The address is what users message to talk to the hub. The easiest option is a **chatmail** account (instant, bot-friendly): see [`docs/accounts-and-chatmail.md`](docs/accounts-and-chatmail.md) for how to get one and the full operator walkthrough.
+- The native **`libdeltachat` / `deltachat-core`** library installed on the system. The `deltachat` Python package binds to it.
 
 ## Install
 
@@ -73,8 +73,8 @@ The bridge forwards the message to the hub, waits for the `speak` reply, and ans
 
 | Option | Description | Default |
 | --- | --- | --- |
-| `--email` | Bot mailbox address | — |
-| `--email-password` | Bot mailbox password | — |
+| `--email` | Bot mailbox address | none |
+| `--email-password` | Bot mailbox password | none |
 | `--key` | HiveMind access key | read from identity file |
 | `--password` | HiveMind password | read from identity file |
 | `--host` | HiveMind host (a `ws://` prefix is added if no scheme) | read from identity file |
@@ -84,10 +84,10 @@ When `--key/--password/--host` are omitted they are read from the stored `NodeId
 
 ## Troubleshooting
 
-- **`NodeIdentity not set`** — run `hivemind-client set-identity`, or pass `--key/--password/--host`.
-- **No reply to messages** — confirm the hub is reachable and the access key is authorized (`hivemind-core list-clients`), and that an OVOS pipeline produces spoken answers.
-- **Mailbox login fails** — verify IMAP/SMTP is enabled for the bot mailbox and the password is an app password where the provider requires one.
-- **`ImportError` on `deltachat`** — install the native `libdeltachat` / `deltachat-core` for your platform.
+- **`NodeIdentity not set`**: run `hivemind-client set-identity`, or pass `--key/--password/--host`.
+- **No reply to messages**: confirm the hub is reachable and the access key is authorized (`hivemind-core list-clients`), and confirm an OVOS pipeline produces spoken answers.
+- **Mailbox login fails**: verify IMAP/SMTP is enabled for the bot mailbox, and that the password is an app password where the provider requires one.
+- **`ImportError` on `deltachat`**: install the native `libdeltachat` / `deltachat-core` for your platform.
 
 ## Documentation
 


### PR DESCRIPTION
Rewrites the README and docs pages in Simplified Technical English for clarity: shorter sentences, no semicolons or em dashes, and consistent terminology. Adds a navigation footer to each docs page (setup, accounts and chatmail, configuration, examples) so readers can move between them in one click.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved wording, punctuation, headings, and formatting across the setup, configuration, examples, accounts, and README documentation.
  * Added navigation links between related guides for easier browsing.
  * Clarified bridge setup instructions, message flow, security notes, troubleshooting guidance, and configuration defaults.
  * Updated email-related defaults to use `none` consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->