### PR TITLE
docs: make the hub allow-msg whitelist step explicit

### DIFF
--- a/docs/accounts-and-chatmail.md
+++ b/docs/accounts-and-chatmail.md
@@ -107,6 +107,10 @@ The hub's spoken reply goes back to the sender's chat.
 - Anyone who knows the bot's address can reach the hub. Restrict access at the hub
   (client ACLs / `allowed_types`) and, once available, the bridge's allowed-senders
   option.
+- A freshly registered client is denied every message type by default:
+  `hivemind-core allow-msg recognizer_loop:utterance deltachat-bridge` and
+  `hivemind-core allow-msg speak deltachat-bridge`. Skipping this leaves the bridge
+  connected but silent.
 
 ## Testing (live e2e)
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,6 +37,13 @@ hivemind-core add-client --name deltachat-bridge \
 
 Keep the access key and password. List clients with `hivemind-core list-clients`.
 
+A freshly registered client can connect, but the hub denies every message type until you whitelist it. Skipping this is the most common reason a bridge connects but never replies:
+
+```bash
+hivemind-core allow-msg recognizer_loop:utterance deltachat-bridge
+hivemind-core allow-msg speak deltachat-bridge
+```
+
 ## Step 3: Prepare the bot mailbox
 
 1. Create or pick an email account for the bot (any IMAP/SMTP provider).

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,15 @@ hivemind-core add-client --name deltachat-bridge \
   --access-key "your-access-key" --password "your-password"
 ```
 
+A new client is registered but mute: the hub denies every message type until you whitelist it. Do this next, or the bridge will connect and never answer:
+
+```bash
+hivemind-core allow-msg recognizer_loop:utterance deltachat-bridge
+hivemind-core allow-msg speak deltachat-bridge
+```
+
+If you run more than one bridge on the same host, give each its own `hivemind-client set-identity` credentials. Bridges sharing an identity share a Noise session pin, and the hub treats reconnects from either as the same client, breaking encryption for both.
+
 **2. Store the HiveMind credentials** so they are read automatically:
 
 ```bash
@@ -87,6 +96,11 @@ When `--key/--password/--host` are omitted they are read from the stored `NodeId
 - **`NodeIdentity not set`**: run `hivemind-client set-identity`, or pass `--key/--password/--host`.
 - **No reply to messages**: confirm the hub is reachable and the access key is authorized (`hivemind-core list-clients`), and confirm an OVOS pipeline produces spoken answers.
 - **Mailbox login fails**: verify IMAP/SMTP is enabled for the bot mailbox, and that the password is an app password where the provider requires one.
+- **Bridge connects but never replies**: the client is registered but not whitelisted. Run `hivemind-core allow-msg recognizer_loop:utterance deltachat-bridge` and `hivemind-core allow-msg speak deltachat-bridge` on the hub.
+- **First message from a new contact gets no reply**: chatmail/Autocrypt treats a brand-new contact as unverified. Add the bot as a contact first (or scan its invite QR) and give it a moment to complete the key exchange before expecting an answer.
+- **`invalid api key` at connect time**: the hub rejected the handshake, usually because the bridge or `hivemind-bus-client` is older than the hub. Upgrade the bridge.
+- **"reconnect worker already running" in the log**: a known issue in older `hivemind-bus-client` releases when a dropped connection retries overlap. Fixed upstream; upgrade `hivemind-bus-client` and the bridge.
+- **Handshake fails after the hub was reinstalled or the client's key changed**: the bridge is holding a stale Noise session pin. Clear it on the hub with `hivemind-core reset-noise-pin deltachat-bridge` and restart the bridge.
 - **`ImportError` on `deltachat`**: install the native `libdeltachat` / `deltachat-core` for your platform.
 
 ## Documentation


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

A fresh client registered with `hivemind-core add-client` connects to the hub but is denied every message type until whitelisted. Nothing in the setup docs told the operator to do this, so the failure mode a beginner hits is: bridge connects, logs look fine, no reply ever comes back, and there is no error to point at the cause.

This adds the `hivemind-core allow-msg recognizer_loop:utterance <name>` and `allow-msg speak <name>` step right after client registration in the README/setup docs, plus troubleshooting entries for the real failure modes seen on a live deployment: stale Noise session pin (`reset-noise-pin`), `invalid api key` from an outdated client, and the (upstream-fixed) reconnect-worker issue. Also notes why bridges sharing a host need separate identities.

Verified against a live 4-bridge deployment (Matrix, Mattermost, DeltaChat, HackChat all connected to one hub) where `list-clients` confirmed each bridge is registered under its own name and the allow-msg step is required for the round trip to work.

No code changes. Docs only.