### PR TITLE
fix: raise hivemind-bus-client floor to >=1.0.13a1, drop <1.0.0 cap

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hivemind-bus-client[async]>=0.9.2a1,<1.0.0
+hivemind-bus-client[async]>=1.0.13a1,<2.0.0
 ovos-utils
 click
 deltachat


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

The pyproject/requirements pin for `hivemind-bus-client` was capped `<1.0.0`, which lets a fresh `pip install` resolve the ancient `0.11.1a1` client. That old client predates the Noise-v3 handshake and cannot connect to a current, crypto-required HiveMind hub — every real deployment has had to manually force-upgrade the dependency after install to get a working bridge.

This bumps the floor to `>=1.0.13a1` (a client that supports the current handshake) and removes the `<1.0.0` cap, allowing (but not requiring) 1.x releases. A `<2.0.0` ceiling is kept as a safety cap against a future breaking major.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Hivemind bus client to a newer compatible release, improving access to the latest supported capabilities and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->