### PR TITLE
Bound the async client's HiveMind handshake retries

### DIFF
--- a/hm_deltachat_bridge/__init__.py
+++ b/hm_deltachat_bridge/__init__.py
@@ -36,6 +36,10 @@ from ovos_utils.log import LOG
 from hm_deltachat_bridge.deltabot import DeltaChatBot
 from hm_deltachat_bridge.version import __version__
 
+# default retry cap for the async client's handshake; unset (None) retries
+# forever and can wedge start() indefinitely if the hub never handshakes.
+DEFAULT_HANDSHAKE_MAX_RETRIES = 10
+
 
 class HiveMindDeltaChatBridge:
     """Bridge between a DeltaChat account and a HiveMind hub.
@@ -97,7 +101,8 @@ class HiveMindDeltaChatBridge:
         self.bot.start()
         LOG.info("== connected to DeltaChat")
 
-        await self.client.connect(site_id="deltachat")
+        await self.client.connect(site_id="deltachat",
+                                   handshake_max_retries=DEFAULT_HANDSHAKE_MAX_RETRIES)
         # speak events on the OVOS bus carry the deltachat_addr we tagged
         # on the outbound utterance; route them back to deltachat.
         self.client.on_mycroft("speak", self._on_speak)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hivemind-bus-client[async]>=1.0.13a1,<2.0.0
+hivemind-bus-client[async]>=1.0.15a1,<2.0.0
 ovos-utils
 click
 deltachat

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -68,15 +68,64 @@ class _StubBot:
             cb(utterance, addr)
 
 
+class _KwargsTolerantFakeBus(AsyncFakeHiveMessageBus):
+    """``AsyncFakeHiveMessageBus`` subclass whose ``connect()`` accepts
+    ``**kwargs``, so it stays a drop-in for the real async client even as
+    the real client's ``connect()`` signature grows new keyword args (e.g.
+    ``handshake_max_retries``) ahead of the published fakebus catching up."""
+
+    async def connect(self, bus=None, protocol=None, site_id=None, **kwargs):
+        return await super().connect(bus=bus, protocol=protocol, site_id=site_id)
+
+
 def _make_bridge() -> HiveMindDeltaChatBridge:
     return HiveMindDeltaChatBridge(
-        client=AsyncFakeHiveMessageBus(site_id="test-deltachat"),
+        client=_KwargsTolerantFakeBus(site_id="test-deltachat"),
         bot=_StubBot(),
     )
 
 
 def _run(coro):
     return asyncio.run(coro)
+
+
+class _RecordingClient(_KwargsTolerantFakeBus):
+    """Fakebus subclass that also records the kwargs ``connect()`` was
+    called with, so tests can assert the bridge bounds the handshake
+    instead of retrying forever."""
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self.connect_calls: list[dict] = []
+
+    async def connect(self, bus=None, protocol=None, site_id=None, **kwargs):
+        self.connect_calls.append({
+            "site_id": site_id,
+            "handshake_max_retries": kwargs.get("handshake_max_retries"),
+        })
+        return await super().connect(bus=bus, protocol=protocol, site_id=site_id)
+
+
+class TestHandshakeBounded(unittest.TestCase):
+    def test_connect_bounds_handshake_retries(self):
+        """start() must not leave the async client retrying the handshake
+        forever — handshake_max_retries must be a finite, non-None value."""
+        bridge = HiveMindDeltaChatBridge(
+            client=_RecordingClient(site_id="test-deltachat"),
+            bot=_StubBot(),
+        )
+
+        async def scenario():
+            await bridge.start()
+            await bridge.stop()
+
+        _run(scenario())
+
+        self.assertEqual(len(bridge.client.connect_calls), 1)
+        retries = bridge.client.connect_calls[0]["handshake_max_retries"]
+        self.assertIsNotNone(retries)
+        self.assertIsInstance(retries, int)
+        self.assertGreater(retries, 0)
 
 
 class TestLifecycle(unittest.TestCase):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

The bridge's `start()` calls `await self.client.connect(site_id="deltachat")` on the async HiveMind client with no `handshake_max_retries`. The async client's default for that parameter is `None`, which means retry forever, so a hub that never completes the handshake leaves `start()` hanging indefinitely and never returns control to the caller.

`AsyncHiveMessageBusClient.connect()` gained `handshake_max_retries` in a recent `hivemind-bus-client` release. The repo's floor (`>=1.0.13a1`) predates that; I checked the actual installed signatures and 1.0.13a1 does not accept the kwarg while 1.0.15a1 (currently the latest published prerelease) does, so I bumped the `[async]` floor to `>=1.0.15a1`. `start()` now passes a finite default of 10 retries unconditionally.

The published `AsyncFakeHiveMessageBus` test double at 1.0.15a1 does not yet accept the new kwarg. I fixed that in the tests rather than in production: a `_KwargsTolerantFakeBus` subclass accepts `**kwargs` on `connect()`, so the existing tests keep exercising the real, unconditional production call instead of a defensive branch.

A new test builds a fakebus subclass that records the kwargs `connect()` is called with, asserting `handshake_max_retries` comes through as a finite positive int. I confirmed it fails against the unfixed source (asserting non-None on a captured `None`) via patch-revert, and passes after restoring the fix. The full unit suite (`tests/test_bridge.py`, `tests/test_smoke.py`) passes 15/15 on Python 3.10, 3.11, 3.12, and 3.13; `tests/e2e/` requires a live DeltaChat account and HiveMind hub and was not run.

`license_check` fails independently of this change: the workflow tries to build the `deltachat` package from source to inspect its license, and that build fails with `pkgconfig.pkgconfig.PackageNotFoundError: deltachat` — the runner is missing the system `libdeltachat`/pkg-config files the classic `deltachat` Python package needs at build time. It never reaches the point of resolving a license classifier for any dependency, so there's no WeakCopyleft/StrongCopyleft offender to react to here; this is a pre-existing CI environment gap unrelated to this PR's diff.